### PR TITLE
Un-ignore `bower.json` from bower-installed files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
   "ignore": [
     "*",
     "!downloads",
-    "!downloads/**/*"
+    "!downloads/**/*",
+    "bower.json"
   ]
 }


### PR DESCRIPTION
At the moment, `bower.json` was in the list of ignored files by Bower when installing the package.
Although Bower creates a `.bower.json` file, some tools out there use this file, like Rails' [sprockets](http://github.com/sstephenson/sprockets).
I suggest to un-ignore this file, like bootstrap, jquery or d3 
