### PR TITLE
POST request no longer contains empty file input

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1080,6 +1080,10 @@ class Dropzone extends Em
     if @element.tagName == "FORM"
       for input in @element.querySelectorAll "input, textarea, select, button"
         inputName = input.getAttribute "name"
+        
+        if inputName == @options.paramName or inputName == @options.paramName + '[]'
+          continue
+        
         inputType = input.getAttribute "type"
 
         if input.tagName == "SELECT" and input.hasAttribute "multiple"


### PR DESCRIPTION
Basic HTML form does not send to server file input in POST request. For example Nette Framework validate it wrong it and throws an error.
