### PR TITLE
added jam requirements to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,9 @@
     "mocha": "^1.18.2",
     "mocha-phantomjs": "^3.3.2",
     "sinon": "1.9.1"
+  },
+  "jam": {
+    "dependencies": {},
+    "main": "./lib/dropzone.js"
   }
 }


### PR DESCRIPTION
added part for jam package manager. 
On http://jamjs.org/docs#Publishing you can see how to publish it.
I think it could be useful to have that as jam is really simple to use and only require one file as mandatory to be included. If you decide not to merge this and not to publish it on jam repo i  will create bare-bone jam package of this repo.

Thanks
