### PR TITLE
Fix Composer package "type" to "component"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "enyo/dropzone",
 	"description": "Handles drag and drop of files for you.",
+	"type": "component",
 	"homepage": "http://www.dropzonejs.com",
 	"keywords": [
 		"dragndrop",


### PR DESCRIPTION
This allows easy deployment of dropzone into a _public_ directory with [component-installer](https://github.com/RobLoach/component-installer) or other various means.
