### PR TITLE
Issue #888 small fix for files with size 0

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -803,7 +803,8 @@ class Dropzone extends Emitter
   # Returns a nicely formatted filesize
   filesize: (size) ->
     units = [ 'TB', 'GB', 'MB', 'KB', 'b' ]
-    selectedSize = selectedUnit = null
+    selectedSize = null
+    selectedUnit = units[units.length - 1]
 
     for unit, i in units
       cutoff = Math.pow(@options.filesizeBase, 4 - i) / 10


### PR DESCRIPTION
https://github.com/enyo/dropzone/issues/888

The file can have size 0 when it was rejected because it has non-acceptable type.
