### PR TITLE
Fixing bug when removingFile (in Chrome, during sending event)

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1214,7 +1214,10 @@ class Dropzone extends Emitter
     # last parameter
     formData.append @_getParamName(i), files[i], files[i].name for i in [0..files.length-1]
 
-    xhr.send formData
+    if xhr.readyState == 1
+      xhr.send formData
+    else
+      xhr
 
 
   # Called internally when processing is finished.


### PR DESCRIPTION
- xhr was not ready to send when we removed the only file, and this was
  throwing exceptions

`removeFile` of a single file in the queue during the `sending` event causes an error in the xhr request

The error was that xhr.send was not available because the xhr was not open / ready.  I was trying to abort file uploads that didn't have a user defined name specified with them (as part of a validation step).

I changed line 1347 in the output javascript as follows and it seems to work correctly.  I have never used coffee script, so the patch may not be correct, but based on the syntax in the file, I believe it to be pretty close

This is the desired resulting javascript diff: L:1374

```
-      return xhr.send(formData);
+      if(xhr.readyState==1) return xhr.send(formData);
+      else return xhr;
```
