### PR TITLE
Removed duplicate filesizeBase property

### DIFF
--- a/dist/dropzone-amd-module.js
+++ b/dist/dropzone-amd-module.js
@@ -137,7 +137,6 @@
       maxThumbnailFilesize: 10,
       thumbnailWidth: 120,
       thumbnailHeight: 120,
-      filesizeBase: 1000,
       maxFiles: null,
       filesizeBase: 1000,
       params: {},

--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -125,7 +125,6 @@
       maxThumbnailFilesize: 10,
       thumbnailWidth: 120,
       thumbnailHeight: 120,
-      filesizeBase: 1000,
       maxFiles: null,
       filesizeBase: 1000,
       params: {},

--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -148,11 +148,6 @@ class Dropzone extends Emitter
     # by this Dropzone
     maxFiles: null
 
-    # The base used to calculate filesizes. 1024 is technically incorrect,
-    # because `1024 bytes` are `1 kibibyte` not `1 kilobyte`.
-    # You can change this to `1024` if you don't care about validity.
-    filesizeBase: 1000
-
     # Can be an object of additional parameters to transfer to the server.
     # This is the same as adding hidden input fields in the form element.
     params: { }


### PR DESCRIPTION
The duplicated filesizeBase property was breaking minifiers with 'use strict' on.
This removes the dupes.

Tests continue to pass, I don't believe this needs another test.
