### PR TITLE
get only buttons with name in the generated form

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1200,7 +1200,7 @@ class Dropzone extends Emitter
 
     # Take care of other input elements
     if @element.tagName == "FORM"
-      for input in @element.querySelectorAll "input, textarea, select, button"
+      for input in @element.querySelectorAll "input, textarea, select, button[name]"
         inputName = input.getAttribute "name"
         inputType = input.getAttribute "type"
 


### PR DESCRIPTION
The is better to get only button with name in generated form, because otherwise all buttons will be added with null name and no value, which has no sense and is not practical for backend validation.
