### PR TITLE
Adds the option to use the original image data for thumbnails

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -140,6 +140,9 @@ class Dropzone extends Emitter
     thumbnailWidth: 120
     thumbnailHeight: 120
 
+    # Setting this to true will skip image resizing all together
+    thumbnailUseRaw: false
+
     # The base that is used to calculate the filesize. You can change this to
     # 1024 if you would rather display kibibytes, mebibytes, etc...
     # 1024 is technically incorrect,
@@ -1006,7 +1009,7 @@ class Dropzone extends Emitter
     fileReader.onload = =>
 
       # Don't bother creating a thumbnail for SVG images since they're vector
-      if file.type == "image/svg+xml"
+      if file.type == "image/svg+xml" or @options.thumbnailUseRaw
         @emit "thumbnail", file, fileReader.result
         callback() if callback?
         return


### PR DESCRIPTION
When both thumbnailWidth and thumbnailHeight are null, the whole image is
redraw. This is not performant for big images. Using the new option
thumbnailUseRaw prevents that.

I'm not aware of any reason to redraw the image again when both thumbnailWidth and thumbnailHeight are null, so ideally the script should set thumbnailUseRaw to true in that case and skip image resampling. Let me know and I may provide a patch for that also.
