### PR TITLE
Add attribute name to the hiddenFileInput

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -623,6 +623,7 @@ class Dropzone extends Emitter
         @hiddenFileInput.parentNode.removeChild @hiddenFileInput if @hiddenFileInput
         @hiddenFileInput = document.createElement "input"
         @hiddenFileInput.setAttribute "type", "file"
+        @hiddenFileInput.setAttribute "name", @options.paramName
         @hiddenFileInput.setAttribute "multiple", "multiple" if !@options.maxFiles? || @options.maxFiles > 1
         @hiddenFileInput.className = "dz-hidden-input"
 


### PR DESCRIPTION
Who forgot to add this?

It was not uploading any file (undefined index file) until I added it, but still not working, is something preventing the files upload in a normal form? Using `processQueue();` and `$("form#id").submit();` The form is submitted but the files are not uploaded (or in that input). http://stackoverflow.com/questions/33695153/cant-upload-multiple-files-with-dropzone

Ok now I know why... https://github.com/enyo/dropzone/issues/1135
