### PR TITLE
Add dz-message even if dropzone element does not have dropzone class

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -615,7 +615,7 @@ class Dropzone extends Emitter
     # In case it isn't set already
     @element.setAttribute("enctype", "multipart/form-data") if @element.tagName == "form"
 
-    if @element.classList.contains("dropzone") and !@element.querySelector(".dz-message")
+    if !@element.querySelector(".dz-message")
       @element.appendChild Dropzone.createElement """<div class="dz-default dz-message"><span>#{@options.dictDefaultMessage}</span></div>"""
 
     if @clickableElements.length


### PR DESCRIPTION
This addresses #655.

I've had trouble running the tests -- after following the CONTRIBUTING.md documentation, I get this error:

```
Error: Cannot find module 'phantomjs'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/Users/phen/Projects/dropzone/node_modules/mocha-phantomjs/bin/mocha-phantomjs:140:17)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:457:10)
npm ERR! Test failed.  See above for more details.
```
