### PR TITLE
Check for parent node before removing child

### DIFF
--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -302,8 +302,8 @@
         var _ref;
         if (file.previewElement) {
           if ((_ref = file.previewElement) != null) {
-          	if(file.previewElement.parentNode) {
-            	_ref.parentNode.removeChild(file.previewElement);
+            if(file.previewElement.parentNode) {
+              _ref.parentNode.removeChild(file.previewElement);
             }
           }
         }

--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -302,7 +302,9 @@
         var _ref;
         if (file.previewElement) {
           if ((_ref = file.previewElement) != null) {
-            _ref.parentNode.removeChild(file.previewElement);
+          	if(file.previewElement.parentNode) {
+            	_ref.parentNode.removeChild(file.previewElement);
+            }
           }
         }
         return this._updateMaxFilesReachedClass();


### PR DESCRIPTION
I just made a change for checking for the presence of the parent node before removing the child. There were times when parentNode was null and was causing a "Cannot call method 'removeChild' of null" error.
