### PR TITLE
Changed drop event "addedfiles" emit order

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -856,8 +856,7 @@ class Dropzone extends Emitter
     @emit "drop", e
 
     files = e.dataTransfer.files
-    @emit "addedfiles", files
-
+    
     # Even if it's a folder, files.length will contain the folders.
     if files.length
       items = e.dataTransfer.items
@@ -866,6 +865,8 @@ class Dropzone extends Emitter
         @_addFilesFromItems items
       else
         @handleFiles files
+        
+    @emit "addedfiles", files
     return
 
   paste: (e) ->


### PR DESCRIPTION
Changed "emit addedfiles" to be after the files are actually added in the "drop" event, so it acts the same as the hiddeninput change event with adding files and emitting "addedFiles"
