### PR TITLE
dictRemoveFile HTML support

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -477,7 +477,7 @@ class Dropzone extends Emitter
     # When the upload is finished, either with success or an error.
     # Receives `file`
     complete: (file) ->
-      file._removeLink.textContent = @options.dictRemoveFile if file._removeLink
+      file._removeLink.innerHTML = @options.dictRemoveFile if file._removeLink
       file.previewElement.classList.add "dz-complete" if file.previewElement
 
     completemultiple: noop


### PR DESCRIPTION
Allows for HTML to be used for the dictRemoveFile option, incase you wish to use icons, etc...

Fixes #221
