### PR TITLE
added feature: dropzone options header as a function

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1211,7 +1211,7 @@ class Dropzone extends Emitter
       "Cache-Control": "no-cache",
       "X-Requested-With": "XMLHttpRequest",
 
-    extend headers, @options.headers if @options.headers
+    extend headers, resolveOption @options.headers if @options.headers
 
     for headerName, headerValue of headers
       xhr.setRequestHeader headerName, headerValue if headerValue


### PR DESCRIPTION
dropzone options header can take in a function which resolves to a header object as well a plain header object (similar to URL).

This is for the use case where you need authorisation headers to be submitted with the file upload request. The user has remained inactive for a period of time, leaving the browser open, the app automatically refreshes the access token. Thus the file upload header needs to be changed as well.
