### PR TITLE
Making Dropzone mobile friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .sass-cache
 _site
 _config.yaml
+.idea

--- a/dist/dropzone-amd-module.js
+++ b/dist/dropzone-amd-module.js
@@ -144,6 +144,7 @@
       ignoreHiddenFiles: true,
       acceptedFiles: null,
       acceptedMimeTypes: null,
+      addAcceptAttribute: true,
       autoProcessQueue: true,
       autoQueue: true,
       addRemoveLinks: false,
@@ -272,7 +273,7 @@
           _ref = file.previewElement.querySelectorAll("[data-dz-name]");
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             node = _ref[_i];
-            node.textContent = this._renameFilename(file.name);
+            node.textContent = this._renameFilename(file.name, file);
           }
           _ref1 = file.previewElement.querySelectorAll("[data-dz-size]");
           for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
@@ -563,7 +564,7 @@
               _this.hiddenFileInput.setAttribute("multiple", "multiple");
             }
             _this.hiddenFileInput.className = "dz-hidden-input";
-            if (_this.options.acceptedFiles != null) {
+            if (_this.options.addAcceptAttribute && (_this.options.acceptedFiles != null)) {
               _this.hiddenFileInput.setAttribute("accept", _this.options.acceptedFiles);
             }
             if (_this.options.capture != null) {
@@ -733,11 +734,11 @@
       }
     };
 
-    Dropzone.prototype._renameFilename = function(name) {
+    Dropzone.prototype._renameFilename = function(name, file) {
       if (typeof this.options.renameFilename !== "function") {
         return name;
       }
-      return this.options.renameFilename(name);
+      return this.options.renameFilename(name, file);
     };
 
     Dropzone.prototype.getFallbackForm = function() {
@@ -1389,7 +1390,7 @@
         }
       }
       for (i = _m = 0, _ref5 = files.length - 1; 0 <= _ref5 ? _m <= _ref5 : _m >= _ref5; i = 0 <= _ref5 ? ++_m : --_m) {
-        formData.append(this._getParamName(i), files[i], this._renameFilename(files[i].name));
+        formData.append(this._getParamName(i), files[i], this._renameFilename(files[i].name, files[i]));
       }
       return this.submitRequest(xhr, formData, files);
     };

--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -132,6 +132,7 @@
       ignoreHiddenFiles: true,
       acceptedFiles: null,
       acceptedMimeTypes: null,
+      addAcceptAttribute: true,
       autoProcessQueue: true,
       autoQueue: true,
       addRemoveLinks: false,
@@ -260,7 +261,7 @@
           _ref = file.previewElement.querySelectorAll("[data-dz-name]");
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             node = _ref[_i];
-            node.textContent = this._renameFilename(file.name);
+            node.textContent = this._renameFilename(file.name, file);
           }
           _ref1 = file.previewElement.querySelectorAll("[data-dz-size]");
           for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
@@ -551,7 +552,7 @@
               _this.hiddenFileInput.setAttribute("multiple", "multiple");
             }
             _this.hiddenFileInput.className = "dz-hidden-input";
-            if (_this.options.acceptedFiles != null) {
+            if (_this.options.addAcceptAttribute && (_this.options.acceptedFiles != null)) {
               _this.hiddenFileInput.setAttribute("accept", _this.options.acceptedFiles);
             }
             if (_this.options.capture != null) {
@@ -721,11 +722,11 @@
       }
     };
 
-    Dropzone.prototype._renameFilename = function(name) {
+    Dropzone.prototype._renameFilename = function(name, file) {
       if (typeof this.options.renameFilename !== "function") {
         return name;
       }
-      return this.options.renameFilename(name);
+      return this.options.renameFilename(name, file);
     };
 
     Dropzone.prototype.getFallbackForm = function() {
@@ -1377,7 +1378,7 @@
         }
       }
       for (i = _m = 0, _ref5 = files.length - 1; 0 <= _ref5 ? _m <= _ref5 : _m >= _ref5; i = 0 <= _ref5 ? ++_m : --_m) {
-        formData.append(this._getParamName(i), files[i], this._renameFilename(files[i].name));
+        formData.append(this._getParamName(i), files[i], this._renameFilename(files[i].name, files[i]));
       }
       return this.submitRequest(xhr, formData, files);
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dropzone",
-  "version": "4.3.0",
+  "version": "4.3.0.mobilefriendly",
   "description": "Handles drag and drop of files for you.",
   "keywords": [
     "dragndrop",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dropzone mobilefriendly",
+  "name": "dropzone",
   "version": "4.3.1",
   "description": "Handles drag and drop of files for you.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dropzone",
-  "version": "4.3.0.mobilefriendly",
+  "name": "dropzone mobilefriendly",
+  "version": "4.3.1",
   "description": "Handles drag and drop of files for you.",
   "keywords": [
     "dragndrop",

--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -165,7 +165,7 @@ class Dropzone extends Emitter
     #
     # The default implementation of the `accept()` function will check this
     # property, and if the Dropzone is clickable this will be used as
-    # `accept` attribute.
+    # `accept` attribute (unless addAcceptAttribute is set to false).
     #
     # This is a comma separated list of mime types or extensions. E.g.:
     #
@@ -178,6 +178,17 @@ class Dropzone extends Emitter
     # @deprecated
     # Use acceptedFiles instead.
     acceptedMimeTypes: null
+
+    # If this property is set to false, the accept property will not be created from
+    # the acceptedFiles property, but dropzone will still check all files which are
+    # attempted to be uploaded.
+    # Said differently: if the user clicks on the upload button the user will have
+    # the opportunity to select any file.
+    # This functionality has been implemented, because some browsers misinterpret
+    # the "accept" attribute in a way where the user is prohibited to select any file.
+    #
+    # For details see http://caniuse.com/#feat=input-file-accept
+    addAcceptAttribute: true
 
     # If false, files will be added to the queue but the queue will not be
     # processed automatically.
@@ -630,7 +641,7 @@ class Dropzone extends Emitter
         @hiddenFileInput.setAttribute "multiple", "multiple" if !@options.maxFiles? || @options.maxFiles > 1
         @hiddenFileInput.className = "dz-hidden-input"
 
-        @hiddenFileInput.setAttribute "accept", @options.acceptedFiles if @options.acceptedFiles?
+        @hiddenFileInput.setAttribute "accept", @options.acceptedFiles if @options.addAcceptAttribute and @options.acceptedFiles?
         @hiddenFileInput.setAttribute "capture", @options.capture if @options.capture?
 
         # Not setting `display="none"` because some browsers don't accept clicks

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -486,10 +486,14 @@ describe "Dropzone", ->
         "using acceptedFiles": new Dropzone(Dropzone.createElement("""<form action="/"></form>"""), { clickable: yes, acceptedFiles: "audio/*,video/*" })
         "using acceptedMimeTypes": new Dropzone(Dropzone.createElement("""<form action="/"></form>"""), { clickable: yes, acceptedMimeTypes: "audio/*,video/*" })
 
+
       it "should not add an accept attribute if no acceptedFiles and no acceptedMimeTypes", ->
         dropzone = new Dropzone (Dropzone.createElement """<form action="/"></form>"""), clickable: yes, acceptedFiles: null, acceptedMimeTypes: null
         dropzone.hiddenFileInput.hasAttribute("accept").should.be.false
 
+      it "should not add an accept attribute if addAcceptAttribute is false, despite having acceptedFiles", ->
+        dropzone = new Dropzone (Dropzone.createElement """<form action="/"></form>"""), clickable: yes, addAcceptAttribute: false, acceptedFiles: "audio/*,video/*" , acceptedMimeTypes: null
+        dropzone.hiddenFileInput.hasAttribute("accept").should.be.false
 
       for name, dropzone of dropzones
         describe name, ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -486,8 +486,8 @@ describe "Dropzone", ->
         "using acceptedFiles": new Dropzone(Dropzone.createElement("""<form action="/"></form>"""), { clickable: yes, acceptedFiles: "audio/*,video/*" })
         "using acceptedMimeTypes": new Dropzone(Dropzone.createElement("""<form action="/"></form>"""), { clickable: yes, acceptedMimeTypes: "audio/*,video/*" })
 
-      it "should not add an accept attribute if no acceptParameter", ->
-        dropzone = new Dropzone (Dropzone.createElement """<form action="/"></form>"""), clickable: yes, acceptParameter: null, acceptedMimeTypes: null
+      it "should not add an accept attribute if no acceptedFiles and no acceptedMimeTypes", ->
+        dropzone = new Dropzone (Dropzone.createElement """<form action="/"></form>"""), clickable: yes, acceptedFiles: null, acceptedMimeTypes: null
         dropzone.hiddenFileInput.hasAttribute("accept").should.be.false
 
 
@@ -498,7 +498,7 @@ describe "Dropzone", ->
               dropzone.hiddenFileInput.should.be.ok
               dropzone.hiddenFileInput.tagName.should.equal "INPUT"
 
-            it "should use the acceptParameter", ->
+            it "should add an accept attribute if either acceptedFiles or acceptedMimeTypes is set", ->
               dropzone.hiddenFileInput.getAttribute("accept").should.equal "audio/*,video/*"
 
             it "should create a new input element when something is selected to reset the input field", ->
@@ -512,7 +512,7 @@ describe "Dropzone", ->
 
     it "should create a .dz-message element", ->
       element = Dropzone.createElement """<form class="dropzone" action="/"></form>"""
-      dropzone = new Dropzone element, clickable: yes, acceptParameter: null, acceptedMimeTypes: null
+      dropzone = new Dropzone element, clickable: yes, acceptedFiles: null, acceptedMimeTypes: null
       element.querySelector(".dz-message").should.be.instanceof Element
 
     it "should not create a .dz-message element if there already is one", ->
@@ -520,7 +520,7 @@ describe "Dropzone", ->
       msg = Dropzone.createElement """<div class="dz-message">TEST</div>"""
       element.appendChild msg
 
-      dropzone = new Dropzone element, clickable: yes, acceptParameter: null, acceptedMimeTypes: null
+      dropzone = new Dropzone element, clickable: yes, acceptedFiles: null, acceptedMimeTypes: null
       element.querySelector(".dz-message").should.equal msg
 
       element.querySelectorAll(".dz-message").length.should.equal 1

--- a/test/test.js
+++ b/test/test.js
@@ -680,11 +680,21 @@
             acceptedMimeTypes: "audio/*,video/*"
           })
         };
-        it("should not add an accept attribute if no acceptParameter", function() {
+        it("should not add an accept attribute if no acceptedFiles and no acceptedMimeTypes", function() {
           var dropzone;
           dropzone = new Dropzone(Dropzone.createElement("<form action=\"/\"></form>"), {
             clickable: true,
-            acceptParameter: null,
+            acceptedFiles: null,
+            acceptedMimeTypes: null
+          });
+          return dropzone.hiddenFileInput.hasAttribute("accept").should.be["false"];
+        });
+        it("should not add an accept attribute if addAcceptAttribute is false, despite having acceptedFiles", function() {
+          var dropzone;
+          dropzone = new Dropzone(Dropzone.createElement("<form action=\"/\"></form>"), {
+            clickable: true,
+            addAcceptAttribute: false,
+            acceptedFiles: "audio/*,video/*",
             acceptedMimeTypes: null
           });
           return dropzone.hiddenFileInput.hasAttribute("accept").should.be["false"];
@@ -698,7 +708,7 @@
                 dropzone.hiddenFileInput.should.be.ok;
                 return dropzone.hiddenFileInput.tagName.should.equal("INPUT");
               });
-              it("should use the acceptParameter", function() {
+              it("should add an accept attribute if either acceptedFiles or acceptedMimeTypes is set", function() {
                 return dropzone.hiddenFileInput.getAttribute("accept").should.equal("audio/*,video/*");
               });
               return it("should create a new input element when something is selected to reset the input field", function() {
@@ -724,7 +734,7 @@
         element = Dropzone.createElement("<form class=\"dropzone\" action=\"/\"></form>");
         dropzone = new Dropzone(element, {
           clickable: true,
-          acceptParameter: null,
+          acceptedFiles: null,
           acceptedMimeTypes: null
         });
         return element.querySelector(".dz-message").should.be["instanceof"](Element);
@@ -736,7 +746,7 @@
         element.appendChild(msg);
         dropzone = new Dropzone(element, {
           clickable: true,
-          acceptParameter: null,
+          acceptedFiles: null,
           acceptedMimeTypes: null
         });
         element.querySelector(".dz-message").should.equal(msg);


### PR DESCRIPTION
This fork intends to solve issue #1329 above all.

The problem is that most mobile browsers implement the accept attribute for file inputs in a terrible way: some prevent the user from selecting _any_ file at all, if the accept attribute is set, thus making an upload unusable for them.

For details refer to http://caniuse.com/#feat=input-file-accept

This pull requests implements the addAcceptAttribute option which prevents the accept attribute from being created.

User agent detection was intentionally left out of this implementation.
A possible setup for user agent detection is provided here
https://gist.github.com/valioDOTch/8ae329326fc24056fc88c1b7a2e185d1
