### PR TITLE
Make Upload Keyboard Accessible

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -620,7 +620,7 @@ class Dropzone extends Emitter
     @element.setAttribute("enctype", "multipart/form-data") if @element.tagName == "form"
 
     if @element.classList.contains("dropzone") and !@element.querySelector(".dz-message")
-      @element.appendChild Dropzone.createElement """<div class="dz-default dz-message"><span>#{@options.dictDefaultMessage}</span></div>"""
+      @element.appendChild Dropzone.createElement """<div class="dz-default dz-message"><a href="#"><span>#{@options.dictDefaultMessage}</span></a></div>"""
 
     if @clickableElements.length
       setupHiddenFileInput = =>

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1242,7 +1242,7 @@ describe "Dropzone", ->
         dropzone.options.previewTemplate = """
                                             <div class="dz-preview dz-file-preview">
                                               <div class="dz-details">
-                                                <div class="dz-filename"><span data-dz-name></span></div>
+                                                <div class="dz-filename"><a href="#"><span data-dz-name></span></a></div>
                                                 <div class="dz-size" data-dz-size></div>
                                                 <img data-dz-thumbnail />
                                               </div>


### PR DESCRIPTION
Dropzone is currently not accessible to keyboard users when it comes to uploading photos.  Adding this a href around the span class helps solve that issue.

https://stackoverflow.com/questions/17354364/how-to-make-an-entire-div-clickable-with-css
