### PR TITLE
Getting the end of the chunk was using the untransformed file

### DIFF
--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -2458,7 +2458,7 @@ function (_Emitter) {
             if (chunkIndex >= file.upload.totalChunkCount) return;
             startedChunkCount++;
             var start = chunkIndex * _this15.options.chunkSize;
-            var end = Math.min(start + _this15.options.chunkSize, file.size);
+            var end = Math.min(start + _this15.options.chunkSize, _transformedFile.size);
             var dataBlock = {
               name: _this15._getParamName(0),
               data: _transformedFile.webkitSlice ? _transformedFile.webkitSlice(start, end) : _transformedFile.slice(start, end),


### PR DESCRIPTION
This was causing the last chunk to be empty or small. Using the transformedFile matches the number of chunks the upload has been split into.