### PR TITLE
(minor) Update links to repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "bugs": {
     "email": "m@tias.me",
-    "url": "https://gitlab.com/meno/dropzone/issues"
+    "url": "https://github.com/dropzone/dropzone/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://gitlab.com/meno/dropzone.git"
+    "url": "https://github.com/dropzone/dropzone.git"
   },
   "devDependencies": {
     "@babel/core": "^7.11.0",


### PR DESCRIPTION
The switch back to GitHub seems to have caused some confusion (e.g. https://gitlab.com/meno/dropzone/-/issues/291); seems reasonable to link to GH if that is where you are now based.

Also Dependabot is creating PRs which link to GitLab, e.g. the link "compare view" in https://github.com/camdram/camdram/pull/1244.