### PR TITLE
Fixes #1914 upload progress for chunking

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -1601,7 +1601,9 @@ export default class Dropzone extends Emitter {
       }
     }
 
-    this._updateFilesUploadProgress(files);
+    if (!files[0].upload.chunked) {
+      this._updateFilesUploadProgress(files);
+    }
 
     if (!(200 <= xhr.status && xhr.status < 300)) {
       this._handleUploadError(files, xhr, response);

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -1281,7 +1281,7 @@ export default class Dropzone extends Emitter {
           this._uploadData(files, [dataBlock]);
         };
 
-        file.upload.finishedChunkUpload = (chunk) => {
+        file.upload.finishedChunkUpload = (chunk, response) => {
           let allFinished = true;
           chunk.status = Dropzone.SUCCESS;
 
@@ -1301,7 +1301,7 @@ export default class Dropzone extends Emitter {
 
           if (allFinished) {
             this.options.chunksUploaded(file, () => {
-              this._finished(files, "", null);
+              this._finished(files, response, null);
             });
           }
         };
@@ -1609,7 +1609,7 @@ export default class Dropzone extends Emitter {
       this._handleUploadError(files, xhr, response);
     } else {
       if (files[0].upload.chunked) {
-        files[0].upload.finishedChunkUpload(this._getChunk(files[0], xhr));
+        files[0].upload.finishedChunkUpload(this._getChunk(files[0], xhr), response);
       } else {
         this._finished(files, response, e);
       }


### PR DESCRIPTION
I _think_ I may have a fix for #1914.  By think I mean it works for chunked and non-chunked, but I wasn't sure if this is the correct place to fix it or if the `_updateFilesUploadProgress` needs to not assume it is finished when no event is provided during chunking

It also appeared to not be sending the server response back to the success event when in chunk mode