### PR TITLE
Fixed #1956 Skipping thumbnail generation on TIFF

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -926,8 +926,10 @@ export default class Dropzone extends Emitter {
     fileReader.onload = () => {
       file.dataURL = fileReader.result;
 
-      // Don't bother creating a thumbnail for SVG images since they're vector
-      if (file.type === "image/svg+xml") {
+      // Not all images are created equal.
+      // Some doesn't need a thumbnail (Vecor based), others have poor adoption and cannot be handled by the browser (TIFF)
+      // In any case we skip creating a thumbnail
+      if (file.type === "image/svg+xml" || file.type === "image/tiff") {
         if (callback != null) {
           callback(fileReader.result);
         }


### PR DESCRIPTION
This PR won't address that the browser cannot render the image. That case still needs to be handled in `thumbnail ` event. e.g 

```
myDropzone.on("thumbnail",
    function (file, dataUrl) {
        if (file.type === "image/tiff") {
            const thumbnail = file.previewElement.querySelector("[data-dz-thumbnail]");
            thumbnail.remove();
            
            // Add an icon or something
        }
});
```