### PR TITLE
Bump sass and migrate / to math.div()

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mocha-headless-chrome": "^3.0.0",
     "rollup": "^2.38.4",
     "rollup-plugin-html": "^0.2.1",
-    "sass": "^1.0.0",
+    "sass": "^1.33.0",
     "sass-loader": "^11.0.1",
     "sinon": "^9.2.4",
     "sinon-chai": "^3.5.0",

--- a/src/basic.scss
+++ b/src/basic.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .dropzone, .dropzone * {
   box-sizing: border-box;
 }
@@ -46,7 +48,7 @@
       width: 54px;
       height: 58px;
       left: 50%;
-      margin-left: -(54px/2);
+      margin-left: -(math.div(54px, 2));
     }
 
 

--- a/src/dropzone.scss
+++ b/src/dropzone.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @mixin keyframes($name) {
   @-webkit-keyframes #{$name} {
     @content; 
@@ -283,8 +285,8 @@
       display: block;
       top: 50%;
       left: 50%;
-      margin-left: -($image-width/2);
-      margin-top: -($image-height/2);
+      margin-left: -(math.div($image-width, 2));
+      margin-top: -(math.div($image-height, 2));
 
       svg {
         display: block;
@@ -383,7 +385,7 @@
         content: '';
         position: absolute;
         top: -6px;
-        left: $width / 2 - 6px;
+        left: math.div($width, 2) - 6px;
         width: 0; 
         height: 0; 
         border-left: 6px solid transparent;


### PR DESCRIPTION
[Using `/` for division has been deprecated in Sass.](https://sass-lang.com/documentation/breaking-changes/slash-div)

I've updated the source to use `math.div()` and bumped the required Dart Sass version to [1.33](https://sass-lang.com/documentation/breaking-changes/slash-div#transition-period).