### PR TITLE
Fix maxFiles issue when added files from server

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -960,6 +960,11 @@ export default class Dropzone extends Emitter {
     crossOrigin,
     resizeThumbnail = true
   ) {
+    mockFile.accepted = true;
+    mockFile.status = Dropzone::Dropzone.SUCCESS;
+    this.files.push(mockFile)
+    this._updateMaxFilesReachedClass();
+
     this.emit("addedfile", mockFile);
     this.emit("complete", mockFile);
 


### PR DESCRIPTION
Files added by displayExistingFiles are not counted to files limit when maxFiles is set.