### PR TITLE
Fix incorrect resize method used for creating thumbnails of existing files

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -977,7 +977,7 @@ export default class Dropzone extends Emitter {
         mockFile,
         this.options.thumbnailWidth,
         this.options.thumbnailHeight,
-        this.options.resizeMethod,
+        this.options.thumbnailMethod,
         this.options.fixOrientation,
         onDone,
         crossOrigin


### PR DESCRIPTION
Noticed this small error in the displayExistingFile() function. displayExistingFile() is used to add files that exist server side to the Dropzone instance. The thumbnail created should use the thumbnail settings - not the resize settings used to permanently resize the image before upload. 